### PR TITLE
Refactor(env.py): change method of using environment variables for database URL instead of alembic.ini

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -63,7 +63,7 @@ version_path_separator = os
 # are written from script.py.mako
 # output_encoding = utf-8
 
-; sqlalchemy.url = 
+sqlalchemy.url = ${DATABASE_URL}
 
 [post_write_hooks]
 # post_write_hooks defines scripts or Python functions that are run

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -10,19 +10,12 @@ from src.experiments.models import Base
 import os
 from dotenv import load_dotenv
 
-load_dotenv()
-db_username = os.getenv("DATABASE_USERNAME")
-db_password = os.getenv("DATABASE_PASSWORD")
 
+load_dotenv()
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config
-
-if not config.get_main_option("sqlalchemy.url"):
-    config.set_main_option(
-        "squlalchemy.url",
-        f"mysql+mysqlconnector://{db_username}:{db_password}@localhost/test_db_2",
-    )
+config.set_main_option("sqlalchemy.url", os.getenv("DATABASE_URL"))
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.


### PR DESCRIPTION
Changed method of using environment variable